### PR TITLE
Fix typo - encoded_name -> encoded_name()

### DIFF
--- a/src/personalisation/adapters.py
+++ b/src/personalisation/adapters.py
@@ -58,7 +58,7 @@ class SessionSegmentsAdapter(BaseSegmentsAdapter):
     def add(self, segment):
         def check_if_segmented(item):
             """Check if the user has been segmented"""
-            return any(seg['encoded_name'] == item.encoded_name for seg in self.request.session['segments'])
+            return any(seg['encoded_name'] == item.encoded_name() for seg in self.request.session['segments'])
 
         if not check_if_segmented(segment):
             segdict = {


### PR DESCRIPTION
Just a small typo that causes bloating user session with repeated segments, e.g.
```python
[
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724164,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724165,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724166,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724167,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724167,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724168,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724170,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724205,
        },
    {
        'persistent': True,
        'encoded_name': 'test',
        'id': 5,
        'timestamp': 1492724219,
        },
    ]
```