### PR TITLE
Add an option to show a personalised block to everyone (no segment)

### DIFF
--- a/src/wagtail_personalisation/blocks.py
+++ b/src/wagtail_personalisation/blocks.py
@@ -8,6 +8,7 @@ from wagtail_personalisation.models import Segment
 
 
 def list_segment_choices():
+    yield -1, ("Show to everyone")
     for pk, name in Segment.objects.values_list('pk', 'name'):
         yield pk, name
 
@@ -35,10 +36,19 @@ class PersonalisedStructBlock(blocks.StructBlock):
         adapter = get_segment_adapter(request)
         user_segments = adapter.get_segments()
 
-        if value['segment']:
+        try:
+            segment_id = int(value['segment'])
+        except (ValueError, TypeError):
+            return ''
+
+        if segment_id > 0:
             for segment in user_segments:
-                if segment.id == int(value['segment']):
+                if segment.id == segment_id:
                     return super(PersonalisedStructBlock, self).render(
                         value, context)
 
-        return ""
+        if segment_id == -1:
+            return super(PersonalisedStructBlock, self).render(
+                value, context)
+
+        return ''


### PR DESCRIPTION
This PR introduces an option to the default `PersonalisableStructBlock` of showing a block to everyone. It's helpful because:

- It avoids a lot of blocks making the streamfield UI look crowded, e.g. a need of having personalised and not personalised blocks definitions separately.
- Currently editors have to copy and paste content between the blocks if they want to show a personalised content to everyone.