### PR TITLE
Return 404 if variant page is accessed directly

### DIFF
--- a/src/wagtail_personalisation/wagtail_hooks.py
+++ b/src/wagtail_personalisation/wagtail_hooks.py
@@ -4,6 +4,7 @@ import logging
 
 from django.conf.urls import include, url
 from django.db import transaction
+from django.http import Http404
 from django.shortcuts import redirect, render
 from django.template.defaultfilters import pluralize
 from django.urls import reverse
@@ -104,9 +105,13 @@ def serve_variant(page, request, serve_args, serve_kwargs):
     adapter = get_segment_adapter(request)
     user_segments = adapter.get_segments()
 
-    if user_segments:
-        metadata = page.personalisation_metadata
+    metadata = page.personalisation_metadata
 
+    # If page is not canonical, don't serve it.
+    if not metadata.is_canonical:
+        raise Http404
+
+    if user_segments:
         # TODO: This is never more then one page? (fix query count)
         metadata = metadata.metadata_for_segments(user_segments)
         if metadata:

--- a/tests/unit/test_wagtail_hooks.py
+++ b/tests/unit/test_wagtail_hooks.py
@@ -1,4 +1,7 @@
 import pytest
+
+from django.http import Http404
+
 from wagtail.core.models import Page
 
 from tests.factories.segment import SegmentFactory
@@ -14,6 +17,15 @@ def test_serve_variant_no_variant(site, rf):
 
     result = wagtail_hooks.serve_variant(page, request, args, kwargs)
     assert result is None
+
+
+@pytest.mark.django_db
+def test_variant_accessed_directly_returns_404(segmented_page, rf):
+    request = rf.get('/')
+    args = tuple()
+    kwargs = {}
+    with pytest.raises(Http404):
+        wagtail_hooks.serve_variant(segmented_page, request, args, kwargs)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
I may not understand the concept behind variant pages, but it seems to me that they should not be accessible publicly. I've created a PR that makes all variants return 404. Shouldn't the only way for the public to access the variant be via the segmentation?