### PR TITLE
Fix is_authenticated 'bool' object is not callable error

### DIFF
--- a/src/wagtail_personalisation/rules.py
+++ b/src/wagtail_personalisation/rules.py
@@ -419,7 +419,7 @@ class UserIsLoggedInRule(AbstractBaseRule):
         verbose_name = _('Logged in Rule')
 
     def test_user(self, request=None):
-        return request.user.is_authenticated() == self.is_logged_in
+        return request.user.is_authenticated == self.is_logged_in
 
     def description(self):
         return {


### PR DESCRIPTION
When adding "user is logged in" flag to a page variation and then visit the page it gives a "'bool' object is not callable" error. is_authenticated is not a function anymore. 

Django version: 2.1.11
Wagtail: 2.4