### PR TITLE
Upgrade to Wagtail 7.3, Django 5.1/5.2, Python 3.13/3.14; drop Wagtail < 6.3

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,10 +7,10 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: pip install tox
       - name: Validate formatting
@@ -21,14 +21,15 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -37,7 +38,7 @@ jobs:
         run: tox
       - name: Prepare artifacts
         run: mkdir -p .coverage-data && mv .coverage.* .coverage-data/
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python }}
           path: .coverage-data/

--- a/sandbox/sandbox/settings.py
+++ b/sandbox/sandbox/settings.py
@@ -14,8 +14,6 @@ from __future__ import absolute_import, unicode_literals
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-from importlib.util import find_spec
-from wagtail import VERSION as WAGTAIL_VERSION
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -55,7 +53,7 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail",
-    "wagtail_modeladmin" if WAGTAIL_VERSION >= (5, 1) else "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin",
     "wagtailfontawesomesvg",
     "modelcluster",
     "taggit",
@@ -79,10 +77,7 @@ MIDDLEWARE = [
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 
-if find_spec("wagtail.contrib.legacy"):
-    MIDDLEWARE += ("wagtail.contrib.legacy.sitemiddleware.SiteMiddleware",)
-else:
-    MIDDLEWARE += ("wagtail.middleware.SiteMiddleware",)
+MIDDLEWARE += ("wagtail.middleware.SiteMiddleware",)
 
 ROOT_URLCONF = "sandbox.urls"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ tag_name = {new_version}
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = tests.settings
-minversion = 3.0
+minversion = 7.4
 strict = true
 django_find_project = false
 testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ minversion = 7.4
 strict = true
 django_find_project = false
 testpaths = tests
-python_paths = .
+pythonpath = .
 
 [flake8]
 ignore = E731,W503

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ tests_require = [
     "freezegun>=1.5.0",
     "pytest-cov>=4.0.0",
     "pytest-django>=4.8.0",
-    "pytest-pythonpath==0.7.4",
     "pytest-sugar>=0.9.4",
     "pytest>=7.4.0",
     "wagtail_factories>=4.2.0",

--- a/setup.py
+++ b/setup.py
@@ -3,27 +3,27 @@ import re
 from setuptools import find_packages, setup
 
 install_requires = [
-    "wagtail>=4.1",
+    "wagtail>=6.3",
+    "wagtail-modeladmin>=1.0",
     "user-agents>=1.1.0",
     "wagtail-font-awesome-svg>=1.0.1",
     "pycountry",
 ]
 
 tests_require = [
-    "factory_boy==3.2.1",
+    "factory_boy>=3.3.0",
     "flake8-blind-except",
     "flake8-debugger",
     "flake8-isort",
     "flake8",
-    "freezegun==1.2.1",
-    "pytest-cov==3.0.0",
-    "pytest-django==4.5.2",
+    "freezegun>=1.5.0",
+    "pytest-cov>=4.0.0",
+    "pytest-django>=4.8.0",
     "pytest-pythonpath==0.7.4",
-    "pytest-sugar==0.9.4",
-    "pytest==6.2.5",
-    "wagtail_factories==4.1.0",
-    "pytest-mock==3.8.1",
-    "wagtail_modeladmin>=1.0",
+    "pytest-sugar>=0.9.4",
+    "pytest>=7.4.0",
+    "wagtail_factories>=4.2.0",
+    "pytest-mock>=3.10.0",
 ]
 
 docs_require = [
@@ -65,8 +65,10 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Framework :: Django",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 6",

--- a/src/wagtail_personalisation/models.py
+++ b/src/wagtail_personalisation/models.py
@@ -194,6 +194,8 @@ class Segment(ClusterableModel):
 
     def get_rules(self):
         """Retrieve all rules in the segment."""
+        if self.pk is None:
+            return []
         segment_rules = []
         for rule_model in AbstractBaseRule.get_descendant_models():
             segment_rules.extend(rule_model._default_manager.filter(segment=self))

--- a/src/wagtail_personalisation/models.py
+++ b/src/wagtail_personalisation/models.py
@@ -1,6 +1,5 @@
 import random
 
-import wagtail
 from django import forms
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -337,10 +336,4 @@ class PersonalisablePageMixin:
         # Do not generate sitemap entries for variants.
         if not self.personalisation_metadata.is_canonical:
             return []
-        if wagtail.VERSION >= (2, 2):
-            # Since Wagtail 2.2 you can pass request to the get_sitemap_urls
-            # method.
-            return super(PersonalisablePageMixin, self).get_sitemap_urls(
-                request=request
-            )
-        return super(PersonalisablePageMixin, self).get_sitemap_urls()
+        return super(PersonalisablePageMixin, self).get_sitemap_urls(request=request)

--- a/src/wagtail_personalisation/rules.py
+++ b/src/wagtail_personalisation/rules.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from importlib import import_module
+from importlib.util import find_spec
 
 import pycountry
 from django.apps import apps
@@ -24,6 +25,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_geoip_module():
+    if not find_spec("geoip2"):
+        return None
     try:
         from django.contrib.gis.geoip2 import GeoIP2
 

--- a/src/wagtail_personalisation/views.py
+++ b/src/wagtail_personalisation/views.py
@@ -7,15 +7,9 @@ from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirec
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.models import Page
-
-if WAGTAIL_VERSION >= (5, 1):
-    from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
-    from wagtail_modeladmin.views import DeleteView, IndexView
-else:
-    from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-    from wagtail.contrib.modeladmin.views import DeleteView, IndexView
+from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail_modeladmin.views import DeleteView, IndexView
 
 from wagtail_personalisation.models import Segment
 from wagtail_personalisation.utils import can_delete_pages

--- a/src/wagtail_personalisation/wagtail_hooks.py
+++ b/src/wagtail_personalisation/wagtail_hooks.py
@@ -8,7 +8,6 @@ from django.template.defaultfilters import pluralize
 from django.urls import include, re_path, reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail import hooks
 from wagtail.admin import messages
 from wagtail.admin.site_summary import PagesSummaryItem, SummaryItem
@@ -126,130 +125,64 @@ def dont_show_variant(parent_page, pages, request):
     return utils.exclude_variants(pages)
 
 
-if WAGTAIL_VERSION >= (5, 2):
+@hooks.register("register_page_listing_buttons")
+def page_listing_variant_buttons(page, user, *args, **kwargs):
+    """Adds page listing buttons to personalisable pages. Shows variants for
+    the page (if any) and a 'Create a new variant' button.
 
-    @hooks.register("register_page_listing_buttons")
-    def page_listing_variant_buttons(page, user, *args, **kwargs):
-        """Adds page listing buttons to personalisable pages. Shows variants for
-        the page (if any) and a 'Create a new variant' button.
+    """
+    if not isinstance(page, models.PersonalisablePageMixin):
+        return
 
-        """
-        if not isinstance(page, models.PersonalisablePageMixin):
-            return
+    metadata = page.personalisation_metadata
 
-        metadata = page.personalisation_metadata
-
-        if metadata.is_canonical:
-            yield ButtonWithDropdownFromHook(
-                _("Variants"),
-                hook_name="register_page_listing_variant_buttons",
-                page=page,
-                user=user,
-                attrs={"target": "_blank", "title": _("Create or edit a variant")},
-                priority=100,
-            )
-
-else:
-
-    @hooks.register("register_page_listing_buttons")
-    def page_listing_variant_buttons(page, page_perms, *args, **is_parent):
-        """Adds page listing buttons to personalisable pages. Shows variants for
-        the page (if any) and a 'Create a new variant' button.
-
-        """
-        if not isinstance(page, models.PersonalisablePageMixin):
-            return
-
-        metadata = page.personalisation_metadata
-
-        if metadata.is_canonical:
-            yield ButtonWithDropdownFromHook(
-                _("Variants"),
-                hook_name="register_page_listing_variant_buttons",
-                page=page,
-                page_perms=page_perms,
-                attrs={"target": "_blank", "title": _("Create or edit a variant")},
-                priority=100,
-            )
-
-
-if WAGTAIL_VERSION >= (5, 2):
-
-    @hooks.register("register_page_listing_variant_buttons")
-    def page_listing_more_buttons(page, user, *args, **kwargs):
-        """Adds a 'more' button to personalisable pages allowing users to quickly
-        create a new variant for the selected segment.
-
-        """
-        if not isinstance(page, models.PersonalisablePageMixin):
-            return
-
-        metadata = page.personalisation_metadata
-
-        for vm in metadata.variants_metadata:
-            yield Button(
-                "%s variant" % (vm.segment.name),
-                reverse("wagtailadmin_pages:edit", args=[vm.variant_id]),
-                attrs={"title": _("Edit this variant")},
-                icon_name="edit",
-                priority=0,
-            )
-
-        for segment in metadata.get_unused_segments():
-            yield Button(
-                "%s variant" % (segment.name),
-                reverse("segment:copy_page", args=[page.pk, segment.pk]),
-                attrs={"title": _("Create this variant")},
-                icon_name="plus",
-                priority=100,
-            )
-
-        yield Button(
-            _("Create a new segment"),
-            reverse("wagtail_personalisation_segment_modeladmin_create"),
-            attrs={"title": _("Create a new segment")},
-            icon_name="snowflake",
-            priority=200,
+    if metadata.is_canonical:
+        yield ButtonWithDropdownFromHook(
+            _("Variants"),
+            hook_name="register_page_listing_variant_buttons",
+            page=page,
+            user=user,
+            attrs={"target": "_blank", "title": _("Create or edit a variant")},
+            priority=100,
         )
 
-else:
 
-    @hooks.register("register_page_listing_variant_buttons")
-    def page_listing_more_buttons(page, page_perms, is_parent=False, *args):
-        """Adds a 'more' button to personalisable pages allowing users to quickly
-        create a new variant for the selected segment.
+@hooks.register("register_page_listing_variant_buttons")
+def page_listing_more_buttons(page, user, *args, **kwargs):
+    """Adds a 'more' button to personalisable pages allowing users to quickly
+    create a new variant for the selected segment.
 
-        """
-        if not isinstance(page, models.PersonalisablePageMixin):
-            return
+    """
+    if not isinstance(page, models.PersonalisablePageMixin):
+        return
 
-        metadata = page.personalisation_metadata
+    metadata = page.personalisation_metadata
 
-        for vm in metadata.variants_metadata:
-            yield Button(
-                "%s variant" % (vm.segment.name),
-                reverse("wagtailadmin_pages:edit", args=[vm.variant_id]),
-                attrs={"title": _("Edit this variant")},
-                classes=("icon", "icon-edit"),
-                priority=0,
-            )
-
-        for segment in metadata.get_unused_segments():
-            yield Button(
-                "%s variant" % (segment.name),
-                reverse("segment:copy_page", args=[page.pk, segment.pk]),
-                attrs={"title": _("Create this variant")},
-                classes=("icon", "icon-plus"),
-                priority=100,
-            )
-
+    for vm in metadata.variants_metadata:
         yield Button(
-            _("Create a new segment"),
-            reverse("wagtail_personalisation_segment_modeladmin_create"),
-            attrs={"title": _("Create a new segment")},
-            classes=("icon", "icon-snowflake"),
-            priority=200,
+            "%s variant" % (vm.segment.name),
+            reverse("wagtailadmin_pages:edit", args=[vm.variant_id]),
+            attrs={"title": _("Edit this variant")},
+            icon_name="edit",
+            priority=0,
         )
+
+    for segment in metadata.get_unused_segments():
+        yield Button(
+            "%s variant" % (segment.name),
+            reverse("segment:copy_page", args=[page.pk, segment.pk]),
+            attrs={"title": _("Create this variant")},
+            icon_name="plus",
+            priority=100,
+        )
+
+    yield Button(
+        _("Create a new segment"),
+        reverse("wagtail_personalisation_segment_modeladmin_create"),
+        attrs={"title": _("Create a new segment")},
+        icon_name="snowflake",
+        priority=200,
+    )
 
 
 class CorrectedPagesSummaryItem(PagesSummaryItem):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,7 +1,5 @@
 import os
 
-from wagtail import VERSION as WAGTAIL_VERSION
-
 DATABASES = {
     "default": {
         "ENGINE": os.environ.get("DATABASE_ENGINE", "django.db.backends.sqlite3"),
@@ -63,7 +61,7 @@ MIDDLEWARE = (
 
 INSTALLED_APPS = (
     "wagtail_personalisation",
-    "wagtail_modeladmin" if WAGTAIL_VERSION >= (5, 1) else "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin",
     "wagtail.search",
     "wagtail.sites",
     "wagtail.users",

--- a/tests/unit/test_rules_country_origin.py
+++ b/tests/unit/test_rules_country_origin.py
@@ -191,8 +191,6 @@ def test_test_user_does_not_use_geoip_module_if_disabled(rf):
 
 @skip_if_geoip2_installed
 def test_get_geoip_module_disabled():
-    with pytest.raises(ImportError):
-        from django.contrib.gis.geoip2 import GeoIP2  # noqa
     assert get_geoip_module() is None
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist =
-    flake8
+    lint
     py310-dj42-wt63
-    py{311,312,313}-dj{42}-wt{70}
-    py{314}-dj{42}-wt{72}
+    py311-dj{42,51}-wt70
+    py312-dj{42,51,52}-wt72
+    py313-dj{42,51,52}-wt73
+    py314-dj52-wt73
 
 [gh-actions]
 python =
@@ -23,16 +25,17 @@ basepython =
 commands = coverage run --parallel -m pytest -rs {posargs}
 extras = test
 deps =
-    dj32: Django>=3.2,<3.3
-    dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
+    dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<5.3
     wt63: wagtail>=6.3,<6.4
     wt70: wagtail>=7.0,<7.1
     wt72: wagtail>=7.2,<7.3
+    wt73: wagtail>=7.3,<7.4
     geoip2: geoip2
 
 [testenv:coverage-report]
-basepython = python3.10
+basepython = python3.12
 deps = coverage
 pip_pre = true
 skip_install = true
@@ -40,14 +43,14 @@ commands =
     coverage report --include="src/**/" --omit="src/**/migrations/*.py"
 
 [testenv:lint]
-basepython = python3.10
+basepython = python3.12
 deps = flake8==3.5.0
 commands =
     flake8 src tests setup.py
     isort --diff src/ tests/
 
 [testenv:format]
-basepython = python3.10
+basepython = python3.12
 deps =
     isort
     black

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py310-dj42-wt63
     py311-dj{42,51}-wt70
     py312-dj{42,51,52}-wt72
-    py313-dj{42,51,52}-wt73
+    py313-dj{51,52}-wt73
     py314-dj52-wt73
 
 [gh-actions]


### PR DESCRIPTION
### Upgrade to Wagtail 7.3, Django 5.1/5.2, Python 3.13/3.14; drop Wagtail < 6.3

  Summary

  - Adds support for Wagtail 7.3, Django 5.1 and 5.2, Python 3.13 and 3.14
  - Drops support for Wagtail < 6.3 — all conditional version-guard code that accumulated over previous
  releases (guarding against Wagtail < 5.1, < 5.2, and < 2.2) has been removed and replaced with the
  current-version behaviour unconditionally
  - Fixes two Django 5.2 compatibility regressions: GeoIP module detection no longer relies on
  ImportError at import time (Django changed this behaviour), and get_rules() now guards against
  filtering by an unsaved model instance
  - Updates the test matrix in tox.ini and CI workflow to reflect the new supported version range
  - Renames CHANGES → CHANGELOG.md
  - Updates documentation screenshots, README compatibility table, and sandbox requirements
  - Adds dark mode and RTL support to the admin UI

  Test plan

  - tox passes across all configured environments (Python 3.10–3.14, Django 4.2–5.2, Wagtail 6.3–7.3)
  - Sandbox boots without errors (python sandbox/manage.py runserver)
  - Segment listing page buttons render correctly (variant dropdown uses updated hook signatures)
  - GeoIP-based country rule behaves correctly when geoip2 package is and isn't installed